### PR TITLE
fix: BGD Second Review Fixes

### DIFF
--- a/script/DeployContracts.s.sol
+++ b/script/DeployContracts.s.sol
@@ -7,14 +7,13 @@ import {OneWayBondingCurve} from "../src/OneWayBondingCurve.sol";
 import {ProposalPayload} from "../src/ProposalPayload.sol";
 
 contract DeployContracts is Script {
-    uint256 private constant ausdcAmount = 350_000e6;
-    uint256 private constant usdcAmount = 700_000e6;
+    uint256 private constant ausdcAmount = 700_000e6;
 
     function run() external {
         vm.startBroadcast();
         OneWayBondingCurve oneWayBondingCurve = new OneWayBondingCurve();
         console.log("One Way Bonding Curve address", address(oneWayBondingCurve));
-        ProposalPayload proposalPayload = new ProposalPayload(oneWayBondingCurve, ausdcAmount, usdcAmount);
+        ProposalPayload proposalPayload = new ProposalPayload(oneWayBondingCurve, ausdcAmount);
         console.log("Proposal Payload address", address(proposalPayload));
         vm.stopBroadcast();
     }

--- a/src/OneWayBondingCurve.sol
+++ b/src/OneWayBondingCurve.sol
@@ -55,10 +55,10 @@ contract OneWayBondingCurve {
 
     /// @notice Purchase USDC for BAL
     /// @param amountIn Amount of BAL input
-    /// @param withdrawFromAave Whether to receive as USDC (true) or aUSDC (false)
+    /// @param toUnderlying Whether to receive as USDC (true) or aUSDC (false)
     /// @return amountOut Amount of USDC received
     /// @dev Purchaser has to approve BAL transfer before calling this function
-    function purchase(uint256 amountIn, bool withdrawFromAave) external returns (uint256) {
+    function purchase(uint256 amountIn, bool toUnderlying) external returns (uint256) {
         if (amountIn == 0) revert OnlyNonZeroAmount();
         if (amountIn > availableBalToBeFilled()) revert ExcessBalAmountIn();
 
@@ -70,7 +70,7 @@ contract OneWayBondingCurve {
 
         // Execute the purchase
         BAL.safeTransferFrom(msg.sender, AaveV2Ethereum.COLLECTOR, amountIn);
-        if (withdrawFromAave) {
+        if (toUnderlying) {
             AUSDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, address(this), amountOut);
             // Compensating for +1/-1 precision issues due to rounding on aTokens while it's being transferred
             amountOut = amountOut - 1;

--- a/src/OneWayBondingCurve.sol
+++ b/src/OneWayBondingCurve.sol
@@ -19,7 +19,6 @@ contract OneWayBondingCurve {
     uint256 public constant BAL_AMOUNT_CAP = 100_000e18;
 
     IERC20 public constant BAL = IERC20(0xba100000625a3754423978a60c9317c58a424e3D);
-    IERC20 public constant ABAL = IERC20(0x272F97b7a56a387aE942350bBC7Df5700f8a4576);
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     IERC20 public constant AUSDC = IERC20(0xBcca60bB61934080951369a648Fb03DF4F96263C);
 
@@ -30,8 +29,8 @@ contract OneWayBondingCurve {
      *   STORAGE VARIABLES   *
      *************************/
 
-    /// @notice Cumulative USDC Purchased
-    uint256 public totalUsdcPurchased;
+    /// @notice Cumulative aUSDC Purchased
+    uint256 public totalAusdcPurchased;
 
     /// @notice Cumulative BAL Received
     uint256 public totalBalReceived;
@@ -41,7 +40,6 @@ contract OneWayBondingCurve {
      **************/
 
     event Purchase(address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut);
-    event Deposit(address indexed token, address indexed aToken, uint256 amount);
 
     /****************************
      *   ERRORS AND MODIFIERS   *
@@ -49,9 +47,6 @@ contract OneWayBondingCurve {
 
     error OnlyNonZeroAmount();
     error ExcessBalAmountIn();
-    error BalCapNotFilled();
-    error ZeroAllowance();
-    error ZeroBalance();
     error InvalidOracleAnswer();
 
     /*****************
@@ -70,13 +65,13 @@ contract OneWayBondingCurve {
         if (amountOut == 0) revert OnlyNonZeroAmount();
 
         totalBalReceived += amountIn;
-        totalUsdcPurchased += amountOut;
+        totalAusdcPurchased += amountOut;
 
         // Execute the purchase
         BAL.safeTransferFrom(msg.sender, AaveV2Ethereum.COLLECTOR, amountIn);
-        USDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, msg.sender, amountOut);
+        AUSDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, msg.sender, amountOut);
 
-        emit Purchase(address(BAL), address(USDC), amountIn, amountOut);
+        emit Purchase(address(BAL), address(AUSDC), amountIn, amountOut);
         return amountOut;
     }
 
@@ -107,43 +102,6 @@ contract OneWayBondingCurve {
         (, int256 price, , , ) = BAL_USD_FEED.latestRoundData();
         if (price <= 0) revert InvalidOracleAnswer();
         return uint256(price);
-    }
-
-    /// @notice Deposit remaining USDC in Aave V2 Collector to earn yield after 100k BAL Amount Cap has been filled
-    function depositUsdcCollector() external {
-        uint256 usdcBalance = USDC.balanceOf(AaveV2Ethereum.COLLECTOR);
-        uint256 usdcAllowance = USDC.allowance(AaveV2Ethereum.COLLECTOR, address(this));
-
-        if (totalBalReceived < BAL_AMOUNT_CAP) revert BalCapNotFilled();
-        if (usdcAllowance == 0) revert ZeroAllowance();
-        if (usdcBalance == 0) revert ZeroBalance();
-
-        // USDC available to Bonding Curve to spend on behalf of Aave V2 Collector
-        uint256 usdcAmount = (usdcAllowance <= usdcBalance) ? usdcAllowance : usdcBalance;
-
-        USDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, address(this), usdcAmount);
-        USDC.approve(address(AaveV2Ethereum.POOL), usdcAmount);
-        AaveV2Ethereum.POOL.deposit(address(USDC), usdcAmount, AaveV2Ethereum.COLLECTOR, 0);
-
-        emit Deposit(address(USDC), address(AUSDC), usdcAmount);
-    }
-
-    /// @notice Deposit all acquired BAL in Aave V2 Collector to earn yield
-    function depositBalCollector() external {
-        uint256 balBalance = BAL.balanceOf(AaveV2Ethereum.COLLECTOR);
-        uint256 balAllowance = BAL.allowance(AaveV2Ethereum.COLLECTOR, address(this));
-
-        if (balAllowance == 0) revert ZeroAllowance();
-        if (balBalance == 0) revert ZeroBalance();
-
-        // BAL available to Bonding Curve to spend on behalf of Aave V2 Collector
-        uint256 balAmount = (balAllowance <= balBalance) ? balAllowance : balBalance;
-
-        BAL.safeTransferFrom(AaveV2Ethereum.COLLECTOR, address(this), balAmount);
-        BAL.approve(address(AaveV2Ethereum.POOL), balAmount);
-        AaveV2Ethereum.POOL.deposit(address(BAL), balAmount, AaveV2Ethereum.COLLECTOR, 0);
-
-        emit Deposit(address(BAL), address(ABAL), balAmount);
     }
 
     /// @notice Transfer any tokens accidentally sent to this contract to Aave V2 Collector

--- a/src/OneWayBondingCurve.sol
+++ b/src/OneWayBondingCurve.sol
@@ -72,9 +72,9 @@ contract OneWayBondingCurve {
         BAL.safeTransferFrom(msg.sender, AaveV2Ethereum.COLLECTOR, amountIn);
         if (toUnderlying) {
             AUSDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, address(this), amountOut);
-            // Compensating for +1/-1 precision issues due to rounding on aTokens while it's being transferred
-            amountOut = amountOut - 1;
-            AaveV2Ethereum.POOL.withdraw(address(USDC), amountOut, msg.sender);
+            // Withdrawing entire aUSDC balance in this contract since we can't directly use 'amountOut' as
+            // input due to +1/-1 precision issues caused by rounding on aTokens while it's being transferred.
+            amountOut = AaveV2Ethereum.POOL.withdraw(address(USDC), type(uint256).max, msg.sender);
             emit Purchase(address(BAL), address(USDC), amountIn, amountOut);
         } else {
             AUSDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, msg.sender, amountOut);

--- a/src/OneWayBondingCurve.sol
+++ b/src/OneWayBondingCurve.sol
@@ -55,7 +55,7 @@ contract OneWayBondingCurve {
 
     /// @notice Purchase USDC for BAL
     /// @param amountIn Amount of BAL input
-    /// @param withdrawFromAave Whether to receive as USDC (True) or aUSDC (False)
+    /// @param withdrawFromAave Whether to receive as USDC (true) or aUSDC (false)
     /// @return amountOut Amount of USDC received
     /// @dev Purchaser has to approve BAL transfer before calling this function
     function purchase(uint256 amountIn, bool withdrawFromAave) external returns (uint256) {
@@ -72,6 +72,8 @@ contract OneWayBondingCurve {
         BAL.safeTransferFrom(msg.sender, AaveV2Ethereum.COLLECTOR, amountIn);
         if (withdrawFromAave) {
             AUSDC.safeTransferFrom(AaveV2Ethereum.COLLECTOR, address(this), amountOut);
+            // Compensating for +1/-1 precision issues due to rounding on aTokens while it's being transferred
+            amountOut = amountOut - 1;
             AaveV2Ethereum.POOL.withdraw(address(USDC), amountOut, msg.sender);
             emit Purchase(address(BAL), address(USDC), amountIn, amountOut);
         } else {

--- a/src/ProposalPayload.sol
+++ b/src/ProposalPayload.sol
@@ -7,7 +7,7 @@ import {AaveV2Ethereum} from "@aave-address-book/AaveV2Ethereum.sol";
 import {IERC20} from "@openzeppelin/token/ERC20/IERC20.sol";
 
 /**
- * @title Payload to approve the One Way Bonding Curve to spend predetermined USDC amount
+ * @title Payload to approve the One Way Bonding Curve to spend predetermined aUSDC amount
  * @author Llama
  * @notice Provides an execute function for Aave governance to execute
  * Governance Forum Post: https://governance.aave.com/t/arc-strategic-partnership-with-balancer-part-2/7813
@@ -20,25 +20,17 @@ contract ProposalPayload {
 
     address public constant USDC_TOKEN = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address public constant AUSDC_TOKEN = 0xBcca60bB61934080951369a648Fb03DF4F96263C;
-    address public constant BAL_TOKEN = 0xba100000625a3754423978a60c9317c58a424e3D;
-    uint256 public constant BAL_AMOUNT = 300_000e18;
 
     OneWayBondingCurve public immutable oneWayBondingCurve;
     uint256 public immutable ausdcAmount;
-    uint256 public immutable usdcAmount;
 
     /*******************
      *   CONSTRUCTOR   *
      *******************/
 
-    constructor(
-        OneWayBondingCurve _oneWayBondingCurve,
-        uint256 _ausdcAmount,
-        uint256 _usdcAmount
-    ) {
+    constructor(OneWayBondingCurve _oneWayBondingCurve, uint256 _ausdcAmount) {
         oneWayBondingCurve = _oneWayBondingCurve;
         ausdcAmount = _ausdcAmount;
-        usdcAmount = _usdcAmount;
     }
 
     /*****************
@@ -47,32 +39,12 @@ contract ProposalPayload {
 
     /// @notice The AAVE governance executor calls this function to implement the proposal.
     function execute() external {
-        // 1. Transfer pre-defined amount of aUSDC tokens to this Proposal Payload contract from AAVE V2 Collector
-        IAaveEcosystemReserveController(AaveV2Ethereum.COLLECTOR_CONTROLLER).transfer(
+        // Approve the One Way Bonding Curve contract to spend pre-defined amount of USDC tokens from AAVE V2 Collector
+        IAaveEcosystemReserveController(AaveV2Ethereum.COLLECTOR_CONTROLLER).approve(
             AaveV2Ethereum.COLLECTOR,
             AUSDC_TOKEN,
-            address(this),
+            address(oneWayBondingCurve),
             ausdcAmount
-        );
-
-        // 2. Redeem aUSDC tokens in this Proposal Payload contract for USDC tokens and send to AAVE V2 Collector
-        AaveV2Ethereum.POOL.withdraw(USDC_TOKEN, ausdcAmount, AaveV2Ethereum.COLLECTOR);
-
-        // 3. Approve the One Way Bonding Curve contract to spend pre-defined amount of USDC tokens from AAVE V2 Collector
-        IAaveEcosystemReserveController(AaveV2Ethereum.COLLECTOR_CONTROLLER).approve(
-            AaveV2Ethereum.COLLECTOR,
-            USDC_TOKEN,
-            address(oneWayBondingCurve),
-            usdcAmount
-        );
-
-        // 4. Approve the One Way Bonding Curve contract to spend 300K BAL from AAVE V2 Collector
-        // 300K BAL = 200K BAL currently in AAVE V2 Collector + 100K BAL to be acquired through Bonding Curve
-        IAaveEcosystemReserveController(AaveV2Ethereum.COLLECTOR_CONTROLLER).approve(
-            AaveV2Ethereum.COLLECTOR,
-            BAL_TOKEN,
-            address(oneWayBondingCurve),
-            BAL_AMOUNT
         );
     }
 }

--- a/src/ProposalPayload.sol
+++ b/src/ProposalPayload.sol
@@ -18,7 +18,6 @@ contract ProposalPayload {
      *   CONSTANTS AND IMMUTABLES   *
      ********************************/
 
-    address public constant USDC_TOKEN = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address public constant AUSDC_TOKEN = 0xBcca60bB61934080951369a648Fb03DF4F96263C;
 
     OneWayBondingCurve public immutable oneWayBondingCurve;

--- a/src/ProposalPayload.sol
+++ b/src/ProposalPayload.sol
@@ -39,7 +39,7 @@ contract ProposalPayload {
 
     /// @notice The AAVE governance executor calls this function to implement the proposal.
     function execute() external {
-        // Approve the One Way Bonding Curve contract to spend pre-defined amount of USDC tokens from AAVE V2 Collector
+        // Approve the One Way Bonding Curve contract to spend pre-defined amount of aUSDC tokens from AAVE V2 Collector
         IAaveEcosystemReserveController(AaveV2Ethereum.COLLECTOR_CONTROLLER).approve(
             AaveV2Ethereum.COLLECTOR,
             AUSDC_TOKEN,

--- a/src/test/OneWayBondingCurveE2E.t.sol
+++ b/src/test/OneWayBondingCurveE2E.t.sol
@@ -81,7 +81,7 @@ contract OneWayBondingCurveE2ETest is Test {
         GovHelpers.passVoteAndExecute(vm, proposalId);
 
         vm.expectRevert(OneWayBondingCurve.OnlyNonZeroAmount.selector);
-        oneWayBondingCurve.purchase(0);
+        oneWayBondingCurve.purchase(0, false);
     }
 
     function testPurchaseZeroAmountOut() public {
@@ -89,7 +89,7 @@ contract OneWayBondingCurveE2ETest is Test {
         GovHelpers.passVoteAndExecute(vm, proposalId);
 
         vm.expectRevert(OneWayBondingCurve.OnlyNonZeroAmount.selector);
-        oneWayBondingCurve.purchase(1e11);
+        oneWayBondingCurve.purchase(1e11, false);
     }
 
     function testPurchaseHitBalCeiling() public {
@@ -106,11 +106,11 @@ contract OneWayBondingCurveE2ETest is Test {
         vm.startPrank(BAL_WHALE);
         BAL.approve(address(oneWayBondingCurve), BAL_AMOUNT_IN);
         vm.expectRevert(OneWayBondingCurve.ExcessBalAmountIn.selector);
-        oneWayBondingCurve.purchase(BAL_AMOUNT_IN);
+        oneWayBondingCurve.purchase(BAL_AMOUNT_IN, false);
         vm.stopPrank();
     }
 
-    function testPurchase() public {
+    function testPurchaseWithdrawFromAaveFalse() public {
         // Pass vote and execute proposal
         GovHelpers.passVoteAndExecute(vm, proposalId);
 
@@ -127,7 +127,7 @@ contract OneWayBondingCurveE2ETest is Test {
 
         vm.expectEmit(true, true, false, true);
         emit Purchase(address(BAL), address(AUSDC), BAL_AMOUNT_IN, 60734568934);
-        uint256 ausdcAmountOut = oneWayBondingCurve.purchase(BAL_AMOUNT_IN);
+        uint256 ausdcAmountOut = oneWayBondingCurve.purchase(BAL_AMOUNT_IN, false);
 
         // Compensating for +1/-1 precision issues when rounding, mainly on aTokens
         assertApproxEqAbs(AUSDC.balanceOf(AaveV2Ethereum.COLLECTOR), initialCollectorAusdcBalance - ausdcAmountOut, 1);
@@ -231,7 +231,7 @@ contract OneWayBondingCurveE2ETest is Test {
      *   POST PROPOSAL EXECUTION FUZZ TESTS  *
      *****************************************/
 
-    function testPurchaseFuzz(uint256 amount) public {
+    function testPurchaseWithdrawFromAaveFalseFuzz(uint256 amount) public {
         // Pass vote and execute proposal
         GovHelpers.passVoteAndExecute(vm, proposalId);
 
@@ -249,7 +249,7 @@ contract OneWayBondingCurveE2ETest is Test {
         assertEq(oneWayBondingCurve.totalAusdcPurchased(), 0);
         assertEq(oneWayBondingCurve.totalBalReceived(), 0);
 
-        uint256 ausdcAmountOut = oneWayBondingCurve.purchase(amount);
+        uint256 ausdcAmountOut = oneWayBondingCurve.purchase(amount, false);
 
         // Compensating for +1/-1 precision issues when rounding, mainly on aTokens
         assertApproxEqAbs(AUSDC.balanceOf(AaveV2Ethereum.COLLECTOR), initialCollectorAusdcBalance - ausdcAmountOut, 1);


### PR DESCRIPTION
## Motivation
BGD Second Review Fixes

## Changes
1. Provide appropriate aUSDC approval to the Bonding Curve contract instead of USDC as part of the proposal payload.
2. Remove both `depositUsdcCollector()` and `depositBalCollector()` functions.
3. Make the `purchase()` function take a bool `toUnderlying` in addition to the `amountIn` parameter: If false, you get aUSDC. If true, you get USDC after withdrawing from Aave.